### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,11 +4,7 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
     autofs: https://github.com/simp/pupmod-simp-autofs
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     nfs: https://github.com/simp/pupmod-simp-nfs
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1
+- Updated a URLs in the README.md
+
 * Mon Nov 05 2018 Liz Nemsick <lnemsick-simp@gmail.com> - 0.1.0
 - Update badges in README.md
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ supported operating systems, Puppet versions, and module dependencies.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_nfs",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for common NFS configurations",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Updated a URL in the README.md

SIMP-6213 #comment pupmod-simp-simp_nfs