### PR TITLE
(SIMP-8460) README allows hostname NFS server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Oct 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1
+* Fri Oct 16 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1
 - Fixed:
   - Removed hostname as a possible entry for the NFS server in the
     sample code in the README. Specifying the NFS server as a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,13 @@
-* Tue Mar 31 2020  <jeannegreulich@onyxpoint.com> - 1.0.0
+* Fri Oct 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1
+- Fixed:
+  - Removed hostname as a possible entry for the NFS server in the
+    sample code in the README. Specifying the NFS server as a
+    hostname is no longer supported due to limitations of firewalld.
+- Updated:
+  - In the README, removed EL6 from the autofs known issue discussion
+    and added more details on how to work around the problem.
+
+* Tue Mar 31 2020  Jeanne Greulich <jeannegreulich@onyxpoint.com> - 1.0.0
 - Added support for EL8
 - Removed support for EL6
 - Updated to use pupmod-simp-nfs release 7.0.0

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ include 'simp_nfs'
 ```yaml
 ---
 simp_options::stunnel: true
-simp_nfs::home_dir_server : <your NFS server IP or Hostname>
+simp_nfs::home_dir_server : <your NFS server IP>
 ```
 
 ### Mount Home NFS Directories on another NFS server
@@ -97,9 +97,9 @@ port then the one the local NFS server is using.
 
 ```ruby
 class  mounthome {
-  class { simp_nfs::mount::home :
-    nfs_server => $home_server,
-    port  => 12049,
+  class { simp_nfs::mount::home:
+    nfs_server        => $home_server,
+    port              => 12049,
     autodetect_remote => false
   }
 }
@@ -115,24 +115,39 @@ See [REFERENCE.md](REFERENCE.md) for details.
 
 ## Known Issues
 
-The ``autofs`` package that was released with CentOS 6.8 (**autofs-5.0.5-122**) worked
-properly over a stunnel connection.
+The ``autofs`` package that was released with CentOS 7.3 (**5.0.7-56**)
+worked properly over a ``stunnel`` connection.
 
-The releases shipped with CentOS 6.9 (**5.0.5-132**)  and with CentOS 7.4 (**5.0.7-69**)
-prevent any connection from happening to the local ``stunnel`` process and
-break mounts to remote systems over ``stunnel`` connections.
+The release shipped with with CentOS 7.4 (**5.0.7-69**) prevents any connection
+from happening to the local ``stunnel`` process and breaks mounts to remote systems
+over ``stunnel`` connections.
 
-The releases that ship with CentOS 6.10 (**5.0.5-139**) and CentOS 7.6
-(**5.0.7-99**) have fixed the issue.
+The release that ship with CentOS 7.6 (**5.0.7-99**) has fixed the issue.
 
-To use NFS over ``stunnel`` on CentOS 6.9 and automount directories the old
-package must be used or you must update to the latest ``autofs`` package.
+To use NFS over ``stunnel`` and ``automount`` directories with old
+CentOS 7 releases, you must use the appropriate ``autofs`` package.
 
-To determine what package is installed on the system, run ``automount -V``.
+To determine what version of ``autofs`` is installed, run ``automount -V``.
+
+To force the package to the desired version:
+
+* Make sure the package is available via your package-management facility then
+  set the package version in Hiera data:
+
+``` yaml
+   autofs::autofs_package_ensure: '5.0.7-99'
+```
+
+* Alternatively, ensure that the latest packages are available and set the
+  following:
+
+``` yaml
+   autofs::autofs_package_ensure: 'latest'
+```
+
 
 The associated bug reports can be found at:
 
-- CentOS 6  https://bugs.centos.org/view.php?id=13575.
 - CentOS 7  https://bugs.centos.org/view.php?id=14080.
 
 ## Limitations

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,7 +35,7 @@ Default value: `false`
 
 ##### `home_dir_server`
 
-Data type: `Optional[Simplib::Host]`
+Data type: `Optional[Simplib::Ip]`
 
 If set, specifies the server from which you want to mount NFS home
 directories for your users
@@ -297,7 +297,7 @@ The following parameters are available in the `simp_nfs::mount::home` class.
 
 ##### `nfs_server`
 
-Data type: `Simplib::Host`
+Data type: `Simplib::IP`
 
 The NFS server to which you will be connecting
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_nfs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "SIMP Team",
   "summary": "A SIMP Puppet Profile for common NFS configurations",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Fixed:
  - Removed hostname as a possible entry for the NFS server in the
    sample code in the README. Specifying the NFS server as a
    hostname is no longer supported due to limitations of firewalld.
- Updated:
  - In the README, removed EL6 from the autofs known issue discussion
    and added more details on how to work around the problem.
- Updated (only of interest to developers):
  - Regenerated the REFERENCE.md using the latest puppet-strings gem.

SIMP-8460 #close