### PR TITLE
(SIMP-9741) Add 389ds to tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,7 @@ fixtures:
     autofs: https://github.com/simp/pupmod-simp-autofs.git
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
     concat: https://github.com/simp/puppetlabs-concat.git
+    ds389: https://github.com/simp/pupmod-simp-ds389.git
     logrotate: https://github.com/simp/pupmod-simp-logrotate.git
     nfs: https://github.com/simp/pupmod-simp-nfs.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
@@ -27,6 +28,7 @@ fixtures:
     rsyslog: https://github.com/simp/pupmod-simp-rsyslog.git
     selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
     simp: https://github.com/simp/pupmod-simp-simp.git
+    simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Tue Jun 22 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 1.1.0
+- Add nfs server certificate information to create_home_directories
+  script.  389ds has client authentication set to require so the
+  certificate information must be sent in the Net::LDAP call.
+- Changes the cron to a systemd timer and remove the script from
+  /etc/cron.hourly.  The script is now located in /usr/local/bin.
+- Add tests with 389ds server
+
 * Thu Jun 17 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.1.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -84,6 +84,9 @@ https://github.com/simp/pupmod-simp-simp_nfs/graphs/contributors
 The following parameters are available in the `simp_nfs::create_home_dirs` class:
 
 * [`uri`](#uri)
+* [`enable`](#enable)
+* [`create_home_script`](#create_home_script)
+* [`run_schedule`](#run_schedule)
 * [`base_dn`](#base_dn)
 * [`bind_dn`](#bind_dn)
 * [`bind_pw`](#bind_pw)
@@ -100,6 +103,8 @@ The following parameters are available in the `simp_nfs::create_home_dirs` class
 * [`pki`](#pki)
 * [`app_pki_external_source`](#app_pki_external_source)
 * [`app_pki_dir`](#app_pki_dir)
+* [`app_pki_key`](#app_pki_key)
+* [`app_pki_cert`](#app_pki_cert)
 * [`app_pki_ca_dir`](#app_pki_ca_dir)
 * [`package_ensure`](#package_ensure)
 
@@ -110,6 +115,32 @@ Data type: `Array[Simplib::URI]`
 The uri(s) of the LDAP servers
 
 Default value: `simplib::lookup('simp_options::ldap::uri')`
+
+##### <a name="enable"></a>`enable`
+
+Data type: `Boolean`
+
+Enable or disable the systemd timer that runs the script to create home
+directories for users.
+
+Default value: ``true``
+
+##### <a name="create_home_script"></a>`create_home_script`
+
+Data type: `Stdlib::AbsolutePath`
+
+The path where to place the script.
+
+Default value: `'/usr/local/bin/create_home_directories.rb'`
+
+##### <a name="run_schedule"></a>`run_schedule`
+
+Data type: `String`
+
+The time schedule for the systemd timer.  See systemd.timer man
+page for correct format.
+
+Default value: `'1 h'`
 
 ##### <a name="base_dn"></a>`base_dn`
 
@@ -241,9 +272,9 @@ Default value: `simplib::lookup('simp_options::openssl::cipher_suite', { 'defaul
 Data type: `Variant[Enum['simp'],Boolean]`
 
 * If 'simp', include SIMP's pki module and use pki::copy to manage
-  application certs in /etc/pki/simp_apps/rsyslog/x509
+  application certs in /etc/pki/simp_apps/nfs_home_server/x509
 * If true, do *not* include SIMP's pki module, but still use pki::copy
-  to manage certs in /etc/pki/simp_apps/rsyslog/x509
+  to manage certs in /etc/pki/simp_apps/nfs_home_server/x509
 * If false, do not include SIMP's pki module and do not use pki::copy
   to manage certs.  You will need to appropriately assign a subset of:
   * app_pki_dir
@@ -271,15 +302,31 @@ Data type: `Stdlib::Absolutepath`
 
 This variable controls the basepath of $app_pki_key, $app_pki_cert,
 $app_pki_ca, $app_pki_ca_dir, and $app_pki_crl.
-It defaults to /etc/pki/simp_apps/<module_name>/pki.
+It defaults to /etc/pki/simp_apps/nfs_home_server/pki.
 
 Default value: `'/etc/pki/simp_apps/nfs_home_server/x509'`
+
+##### <a name="app_pki_key"></a>`app_pki_key`
+
+Data type: `Stdlib::AbsolutePath`
+
+Path and name of the private SSL key file
+
+Default value: `"${app_pki_dir}/private/${facts['fqdn']}.pem"`
+
+##### <a name="app_pki_cert"></a>`app_pki_cert`
+
+Data type: `Stdlib::AbsolutePath`
+
+Path and name of the public SSL certificate
+
+Default value: `"${app_pki_dir}/public/${facts['fqdn']}.pub"`
 
 ##### <a name="app_pki_ca_dir"></a>`app_pki_ca_dir`
 
 Data type: `Stdlib::Absolutepath`
 
-Path to the CA certificates.
+Path to the CA.
 
 Default value: `"${app_pki_dir}/cacerts"`
 

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -26,10 +26,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   client7:
     roles:
@@ -46,15 +42,12 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   server8:
     roles:
       - server
       - nfs_server
+      - 389ds
       - el8
     platform:   el-8-x86_64
     box:        centos/8
@@ -67,10 +60,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   client8:
     roles:
@@ -87,10 +76,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose
@@ -101,6 +86,7 @@ CONFIG:
 <% if ENV['BEAKER_PUPPET_ENVIRONMENT'] -%>
   puppet_environment: <%= ENV['BEAKER_PUPPET_ENVIRONMENT'] %>
 <% end -%>
+  # The following was added because ssh was timing out on gitlab servers
   ssh:
     keepalive: true
     keepalive_interval: 10
@@ -112,4 +98,3 @@ CONFIG:
       - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:encryption].join("\n#{' '*6}- ") %>
     hmac:
       - <%= Net::SSH::Transport::Algorithms::ALGORITHMS[:hmac].join("\n#{' '*6}- ") %>
-

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -15,7 +15,7 @@ HOSTS:
       - el7
       - ldap
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        generic/oracle7
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     yum_repos:
@@ -29,10 +29,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   client7:
     roles:
@@ -40,7 +36,7 @@ HOSTS:
       - agent
       - el7
     platform:   el-7-x86_64
-    box:        onyxpoint/oel-7-x86_64
+    box:        generic/oracle7
     hypervisor: <%= hypervisor %>
     yum_repos:
       simp:
@@ -49,16 +45,13 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   server8:
     roles:
       - simp_server
       - nfs_server
       - el8
+      - 389ds
     platform:   el-8-x86_64
     box:        generic/oracle8
     hypervisor: <%= hypervisor %>
@@ -70,10 +63,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   client8:
     roles:
@@ -90,10 +79,6 @@ HOSTS:
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
           - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-UNSTABLE
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/00_setup_389ds_spec.rb
+++ b/spec/acceptance/suites/default/00_setup_389ds_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper_acceptance'
+
+test_name 'Set up ds389 server '
+
+describe 'simp_nfs stock classes' do
+  #stunnel just needs to be set, it does not effect this test
+  stunnel_setting = true
+  ldap_server = only_host_with_role(hosts,'389ds')
+  ldap_server_fqdn = fact_on(ldap_server, 'fqdn')
+
+  _domains = fact_on(ldap_server, 'domain').split('.')
+  _domains.map! { |d|
+    "dc=#{d}"
+  }
+  domains = _domains.join(',')
+  common_hieradata =  File.read(File.expand_path('files/common_hieradata.yaml.erb', File.dirname(__FILE__)))
+
+  context 'setup 389ds ldap server ' do
+    let(:test_user1)       { 'test.user' }
+    let(:test_user2)       { 'monster.user' }
+    let(:root_pw)          { 'suP3rP@ssw0r!' }
+    let(:ldap_type)        { '389ds' }
+    let(:server_hieradata) { File.read(File.expand_path("files/#{ldap_type}/server_hieradata.yaml.erb", File.dirname(__FILE__))) }
+    let(:hieradata)        { "#{common_hieradata}" + "\n#{server_hieradata}" }
+    let(:add_testuser)     { File.read(File.expand_path("files/#{ldap_type}/add_testuser.erb", File.dirname(__FILE__))) }
+    let(:ds_root_name)     { 'accounts' }
+
+    it 'should install, 389ds accounts instance' do
+
+      server_manifest = <<-EOM
+        include 'simp_options'
+        include 'pam::access'
+        include 'sudo'
+        include 'ssh'
+        include 'simp::nsswitch'
+        include 'simp_ds389::instances::accounts'
+        include 'simp_openldap::client'
+        include 'simp::sssd::client'
+      EOM
+
+      # Apply
+      set_hieradata_on(ldap_server, ERB.new(hieradata).result(binding), 'default')
+      apply_manifest_on(ldap_server, server_manifest, catch_failures: true)
+      apply_manifest_on(ldap_server, server_manifest, catch_failures: true)
+      apply_manifest_on(ldap_server, server_manifest, catch_changes: true)
+    end
+
+    # Create test.user
+    it 'should add the test users' do
+      create_remote_file(ldap_server, '/root/ldap_add_user',ERB.new(add_testuser).result(binding))
+      on(ldap_server, 'chmod +x /root/ldap_add_user')
+      on(ldap_server, '/root/ldap_add_user')
+      result = on(ldap_server, "dsidm #{ds_root_name} -b #{domains} user list")
+      expect(result.stdout).to include("test.user")
+      expect(result.stdout).to include("monster.user")
+    end
+
+    it 'should be able to get user info through sssd' do
+      on(ldap_server, 'service sssd restart')
+
+      user_info = on(ldap_server, "id #{test_user1}", :acceptable_exit_codes => [0])
+      expect(user_info.stdout).to match(/.*uid=10000\(#{test_user1}\).*gid=10000\(#{test_user1}\)/)
+      monster_info = on(ldap_server, "id #{test_user2}", :acceptable_exit_codes => [0])
+      expect(monster_info.stdout).to match(/.*uid=11000\(#{test_user2}\).*gid=11000\(#{test_user2}\)/)
+    end
+
+  end
+end

--- a/spec/acceptance/suites/default/10_default_spec.rb
+++ b/spec/acceptance/suites/default/10_default_spec.rb
@@ -74,6 +74,7 @@ describe 'simp_nfs stock classes' do
 
          set_hieradata_on(ldap_server, ERB.new(common_hieradata + ldap_server_hieradata).result(binding))
          apply_manifest_on(ldap_server, ldap_server_manifest, catch_failures: true)
+         apply_manifest_on(ldap_server, ldap_server_manifest, catch_failures: true)
          apply_manifest_on(ldap_server, ldap_server_manifest, catch_changes: true)
        end
 

--- a/spec/acceptance/suites/default/10_default_spec.rb
+++ b/spec/acceptance/suites/default/10_default_spec.rb
@@ -3,135 +3,174 @@ require 'spec_helper_acceptance'
 test_name 'SIMP NFS profile'
 
 describe 'simp_nfs stock classes' do
+  stunnel_setting = true
+  root_pw = 'suP3rP@ssw0r!'
   servers = hosts_with_role( hosts, 'nfs_server' )
   clients = hosts_with_role( hosts, 'client' )
-  ldap_server = only_host_with_role(hosts,'ldap')
-  ldap_fqdn = fact_on(ldap_server, 'fqdn')
-
-  _domains = fact_on(ldap_server, 'domain').split('.')
-  _domains.map! { |d|
-    "dc=#{d}"
-  }
-  domains = _domains.join(',')
-  hiera_file = File.expand_path('./files/common_hieradata.yaml',File.dirname(__FILE__))
-  hieradata_common = File.read(hiera_file).gsub('SERVERNAME',ldap_fqdn)
-
-  el8_server_host =only_host_with_role(servers,'el8')
-  el8_server = fact_on(el8_server_host, 'fqdn')
-  el8_server_ip = fact_on(el8_server_host,%(ipaddress_#{get_private_network_interface(el8_server_host)}))
-  el7_server_host =only_host_with_role(servers,'el7')
-  el7_server = fact_on(el7_server_host, 'fqdn')
-  el7_server_ip = fact_on(el7_server_host,%(ipaddress_#{get_private_network_interface(el7_server_host)}))
-
-  context 'with exported home directories using stunnel' do
-    hosts.each do |node|
-
-      # Determine who your nfs server is
-      os = fact_on(node, 'operatingsystem')
-      if os =~ /CentOS|RedHat|OracleLinux/
-        os_release = fact_on(node, 'operatingsystemmajrelease')
-        case  os_release
-        when '7'
-          server = el7_server
-          server_ip = el7_server_ip
-        when '8'
-          server = el8_server
-          server_ip = el8_server_ip
-        else
-          STDERR.puts "#{os_release} not a supported OS release"
-          next
-        end
-      else
-        STDERR.puts "OS #{os} not supported"
-        next
-      end
-      nfs_server = server
-      nfs_server_ip = server_ip
-
-      manifest = <<-EOM
-        include 'simp_options'
-        include 'pam::access'
-        include 'sudo'
-        include 'ssh'
-        include 'simp::nsswitch'
-        include 'simp_openldap::client'
-        include 'simp::sssd::client'
-        include 'simp_nfs'
-      EOM
-
-      hieradata_extra = <<-EOM
-
-simp_nfs::home_dir_server: #{nfs_server_ip}
-nfs::client::stunnel::nfs_server: #{nfs_server}
-simp_nfs::mount::home::local_home: /mnt
-      EOM
-
-      if servers.include?(node)
-        it 'should install nfs server' do
-          # Construct server hieradata; export home directories.
-          server_hieradata = hieradata_common + hieradata_extra + <<-EOM.gsub(/^\s+/,'')
-            nfs::is_server: true
-            simp_nfs::export_home::create_home_dirs: true
-          EOM
-          server_manifest = manifest + <<-EOM
+  manifest =  <<-EOM
+    # Make sure vagrant can log back in
+    simp_firewalld::rule { 'allow_all_ssh':
+      trusted_nets => ['all'],
+      protocol     => tcp,
+      dports       => 22
+    }
+    include 'simp_options'
+    include 'pam::access'
+    include 'sudo'
+    include 'ssh'
+    include 'simp::nsswitch'
+    include 'simp_openldap::client'
+    include 'simp::sssd::client'
+    include 'simp_nfs'
+  EOM
+  nfsserver_hieradata = <<~EOM
+             nfs::is_server: true
+             simp_nfs::export_home::create_home_dirs: true
+    EOM
+  nfsserver_manifest = <<-EOM
             include 'simp_nfs::export::home'
             Class['simp::sssd::client'] ->  Class['simp_nfs::export::home']
-          EOM
-          ldap_server_manifest =  server_manifest + <<-EOM
-            # Need to make sure ldap ports don't get removed.
-            include simp::server::ldap
-          EOM
+    EOM
+  clear_sssd_cache = <<~EOM
+    #!/bin/bash
+    if [ -f /var/lib/sss/db/cache_LDAP.ldb ]; then
+      rm -f /var/lib/sss/db/cache_LDAP.ldb
+    fi
+    systemctl restart sssd
+    EOM
 
-          set_hieradata_on(node, server_hieradata, 'default')
-          on(node, 'mkdir -p /usr/local/sbin/simp')
-          if node == ldap_server
-            apply_manifest_on(node, ldap_server_manifest, catch_failures: true)
-            apply_manifest_on(node, ldap_server_manifest, catch_failures: true)
-            apply_manifest_on(node, ldap_server_manifest, catch_changes: true)
-          else
-            apply_manifest_on(node, server_manifest, catch_failures: true)
-            apply_manifest_on(node, server_manifest, catch_failures: true)
-            apply_manifest_on(node, server_manifest, catch_changes: true)
+  ['389ds','plain'].each do  |ldaptype|
+     context "using ldap server type #{ldaptype}" do
+       let(:ldap_type) { ldaptype }
+
+       if ldaptype == '389ds'
+         let(:ldap_server) {only_host_with_role(hosts,'389ds') }
+         let(:ldap_manifest){  <<-EOM
+            include 'simp_ds389::instances::accounts'
+          EOM
+         }
+       else
+         let(:ldap_server) {only_host_with_role(hosts,'ldap') }
+         let(:ldap_manifest){  <<-EOM
+            include 'simp::server::ldap'
+          EOM
+         }
+       end
+       let(:ldap_server_fqdn) { fact_on(ldap_server, 'fqdn')}
+
+       let(:_domains) { fact_on(ldap_server, 'domain').split('.')
+                         _domains.map! { |d|
+                       "dc=#{d}"
+                      }}
+       let(:domains) { _domains.join(',')}
+       let(:common_hieradata)  { File.read(File.expand_path('files/common_hieradata.yaml.erb', File.dirname(__FILE__))) }
+       let(:ldap_server_hieradata) { File.read(File.expand_path("files/#{ldap_type}/server_hieradata.yaml.erb", File.dirname(__FILE__))) }
+
+       it 'should install ldap server' do
+         # This server may have just been an NFS server in a previous test.
+         # We need run puppet again with the ldap manifest to make sure
+         # the firewall is configured correctly.
+         ldap_server_manifest=[manifest, ldap_manifest].join("\n")
+
+         set_hieradata_on(ldap_server, ERB.new(common_hieradata + ldap_server_hieradata).result(binding))
+         apply_manifest_on(ldap_server, ldap_server_manifest, catch_failures: true)
+         apply_manifest_on(ldap_server, ldap_server_manifest, catch_changes: true)
+       end
+
+       servers.each do |server|
+         context "On #{server} with #{ldaptype} ldap server export home directories using stunnel" do
+           let(:nfs_server) { server }
+           let(:nfs_server_ip) {  fact_on(nfs_server,%(ipaddress_#{get_private_network_interface(nfs_server)})) }
+
+           let(:hieradata_extra) {
+             <<~EOM
+             simp_nfs::home_dir_server: #{nfs_server_ip}
+             nfs::client::stunnel::nfs_server: #{nfs_server}
+             simp_nfs::mount::home::local_home: '/mnt'
+             EOM
+           }
+
+           let(:server_hieradata) { [common_hieradata, ldap_server_hieradata,  hieradata_extra, nfsserver_hieradata].join("\n")}
+
+           it 'should clear the sssd cache' do
+             #since we are switching around ldap servers make sure the
+             #sssd cache is clear.  It might have users from
+             #the other ldap server in its cache
+             create_remote_file(nfs_server, '/root/clear_sssd_cache.sh',clear_sssd_cache)
+             on(nfs_server, 'chmod +x /root/clear_sssd_cache.sh')
+             on(nfs_server, '/root/clear_sssd_cache.sh')
+           end
+
+           it 'should install nfs server' do
+             if server == ldap_server
+               # Don't want to erase the ldap server
+               server_manifest=[manifest, nfsserver_manifest, ldap_manifest].join("\n")
+             else
+               server_manifest=[manifest, nfsserver_manifest].join("\n")
+             end
+
+             set_hieradata_on(nfs_server, ERB.new(server_hieradata).result(binding))
+             on(nfs_server, 'mkdir -p /usr/local/sbin/simp')
+             apply_manifest_on(nfs_server, server_manifest, catch_failures: true)
+             apply_manifest_on(nfs_server, server_manifest, catch_failures: true)
+             apply_manifest_on(nfs_server, server_manifest, catch_changes: true)
+           end
+
+           # Ensure the cache is built, don't wait for enum timeout
+           it 'should see the  test user' do
+             user_info = on(nfs_server, 'id test.user', :acceptable_exit_codes => [0])
+             expect(user_info.stdout).to match(/.*uid=10000\(test.user\).*gid=10000\(test.user\)/)
           end
 
-          # Ensure the cache is built, don't wait for enum timeout
-          on(node, 'service sssd restart')
+          it ' should create home dirs and export them' do
+            # Create test.user's homedir via cron, and ensure it gets mounted
+            on(nfs_server, '/usr/local/bin/create_home_directories.rb')
+            on(nfs_server, 'ls /var/nfs/home/test.user')
+            on(nfs_server, "runuser -l test.user -c 'touch ~/testfile'")
+            mount = on(nfs_server, "mount")
+            expect(mount.stdout).to match(/127.0.0.1:\/home\/test.user.*nfs/)
 
-          user_info = on(node, 'id test.user', :acceptable_exit_codes => [0])
-          expect(user_info.stdout).to match(/.*uid=10000\(test.user\).*gid=10000\(test.user\)/)
+            results = on(nfs_server, 'systemctl list-units -t timer').stdout
+            expect(results).to match(/nfs_create_home_dirs\.timer.*loaded.*active/)
+          end
+
+          clients.each do |client|
+            context "On #{client} using #{server} as nfs and #{ldaptype} ldap server using stunnel" do
+              let(:client_hieradata) { [common_hieradata, hieradata_extra].join("\n") }
+              it 'should clean up from any previous tests' do
+                create_remote_file(client, '/root/clear_sssd_cache.sh',clear_sssd_cache)
+                on(client, 'chmod +x /root/clear_sssd_cache.sh')
+                on(client, '/root/clear_sssd_cache.sh', :accept_all_exit_codes => true )
+                on(client,'umount -f /mnt/test.user', :accept_all_exit_codes => true)
+              end
+
+              it "should set up with stunnel #{client}" do
+                set_hieradata_on(client, ERB.new(client_hieradata).result(binding))
+                apply_manifest_on(client, manifest, catch_failures: true)
+                apply_manifest_on(client, manifest, catch_failures: true)
+                apply_manifest_on(client, manifest, catch_changes: true)
+              end
+
+              it 'should see the  test user' do
+                user_info = on(client, 'id test.user', :acceptable_exit_codes => [0])
+                expect(user_info.stdout).to match(/.*uid=10000\(test.user\).*gid=10000\(test.user\)/)
+              end
+
+              it 'should see the file created on the server' do
+                retry_on(client, 'ls /mnt/test.user/testfile', acceptable_exit_codes: [0])
+              end
+
+              it 'should clean up so the next test has no problems with bad mounts' do
+                on(client, 'umount -f /mnt/test.user')
+              end
+            # End client context
+            end
+          end
+        # End server context
         end
-      else
-        it "should set up with stunnel #{node}" do
-          client_hieradata = hieradata_common + hieradata_extra
-          set_hieradata_on(node, client_hieradata, 'default')
-          on(node, 'mkdir -p /usr/local/sbin/simp')
-          apply_manifest_on(node, manifest, catch_failures: true)
-          apply_manifest_on(node, manifest, catch_failures: true)
-          apply_manifest_on(node, manifest, catch_changes: true)
-          #  LDAP server should be set up and the client should be able
-          #  to talk to it.
-          on(node, 'service sssd restart')
-          user_info = on(node, 'id test.user', :acceptable_exit_codes => [0])
-          expect(user_info.stdout).to match(/.*uid=10000\(test.user\).*gid=10000\(test.user\)/)
-        end
       end
-    end
-
-    it 'should create the test.user home directory mount on the servers using the cron job' do
-      servers.each do |node|
-        # Create test.user's homedir via cron, and ensure it gets mounted
-        on(node, '/etc/cron.hourly/create_home_directories.rb')
-        on(node, 'ls /var/nfs/home/test.user')
-        on(node, "runuser -l test.user -c 'touch ~/testfile'")
-        mount = on(node, "mount")
-        expect(mount.stdout).to match(/127.0.0.1:\/home\/test.user.*nfs/)
-      end
-    end
-
-    it 'should have file propagation to the clients' do
-      clients.each do |node|
-        retry_on(node, 'ls /mnt/test.user/testfile', acceptable_exit_codes: [0])
-      end
+    #End Ldap server context
     end
   end
+#End it all
 end

--- a/spec/acceptance/suites/default/11_nostunnel_spec.rb
+++ b/spec/acceptance/suites/default/11_nostunnel_spec.rb
@@ -82,6 +82,7 @@ describe 'simp_nfs stock classes without stunnel' do
 
          set_hieradata_on(ldap_server, ERB.new(common_hieradata + ldap_server_hieradata).result(binding))
          apply_manifest_on(ldap_server, ldap_server_manifest, catch_failures: true)
+         apply_manifest_on(ldap_server, ldap_server_manifest, catch_failures: true)
          apply_manifest_on(ldap_server, ldap_server_manifest, catch_changes: true)
        end
 

--- a/spec/acceptance/suites/default/files/389ds/add_testuser.erb
+++ b/spec/acceptance/suites/default/files/389ds/add_testuser.erb
@@ -1,0 +1,19 @@
+# test user 1
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" posixgroup create --cn <%= test_user1 %> --gidNumber 10000
+
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" user create --cn <%= test_user1 %> --uid <%= test_user1 %> --displayName "Test User" --uidNumber 10000 --gidNumber 10000 --homeDirectory /mnt/<%= test_user1 %>
+
+#suP3rP@ssw0r!
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" user modify <%= test_user1 %> add:userPassword:{SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y
+
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" posixgroup modify administrators add:member:uid=<%= test_user1 %>,ou=People,<%= domains %>
+
+#testuser 2
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" posixgroup create --cn <%= test_user2 %> --gidNumber 11000
+
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" user create --cn <%= test_user2 %> --uid <%= test_user2 %> --displayName "Test User" --uidNumber 11000 --gidNumber 11000 --homeDirectory /mnt1/<%= test_user2 %>
+
+#suP3rP@ssw0r!
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" user modify <%= test_user2 %> add:userPassword:{SSHA}r2GaizHFWY8pcHpIClU0ye7vsO4uHv/y
+
+dsidm "<%= ds_root_name %>" -b "<%= domains %>" posixgroup modify administrators add:member:uid=<%= test_user2 %>,ou=People,<%= domains %>

--- a/spec/acceptance/suites/default/files/389ds/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/files/389ds/server_hieradata.yaml.erb
@@ -1,0 +1,1 @@
+simp_ds389::instances::accounts::root_pw: <%= root_pw %>

--- a/spec/acceptance/suites/default/files/common_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/files/common_hieradata.yaml.erb
@@ -1,13 +1,13 @@
 ---
 simp_options::clamav: false
 simp_options::dns::servers: ['8.8.8.8']
-simp_options::puppet::server: 'SERVERNAME'
-simp_options::puppet::ca:  'SERVERNAME'
-simp::yum::servers: ['SERVERNAME']
+simp_options::puppet::server: '<%= ldap_server_fqdn %>'
+simp_options::puppet::ca:  '<%= ldap_server_fqdn %>'
+simp::yum::servers: ['<%= ldap_server_fqdn %>']
 simp_options::ntpd::servers: ['time.nist.gov']
 simp_options::haveged: true
 simp_options::sssd: true
-simp_options::stunnel: true
+simp_options::stunnel: <%= stunnel_setting %>
 simp_options::tcpwrappers: true
 simp_options::pam: true
 simp_options::firewall: true
@@ -20,16 +20,16 @@ simp_options::ldap::bind_pw: 'foobarbaz'
 simp_options::ldap::bind_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
 simp_options::ldap::sync_pw: 'foobarbaz'
 simp_options::ldap::sync_hash: '{SSHA}BNPDR0qqE6HyLTSlg13T0e/+yZnSgYQz'
-simp_options::ldap::uri: [ "ldap://SERVERNAME"]
-simp_options::ldap::master: "ldap://SERVERNAME"
+simp_options::ldap::uri: [ "ldap://<%= ldap_server_fqdn %>"]
+simp_options::ldap::master: "ldap://<%= ldap_server_fqdn %>"
 # suP3rP@ssw0r!
-simp_openldap::server::conf::rootpw: "{SSHA}TghZyHW6r8/NL4fo0Q8BnihxVb7A7af5"
 sssd::domains:
   - LDAP
 simp::is_mail_server: false
-simp::sssd::client::ldap_server_type: plain
+simp::sssd::client::ldap_server_type: <%= ldap_type %>
 pam::wheel_group: 'administrators'
 firewalld::firewall_backend: 'iptables'
+iptables::use_firewalld: true
 
 # Settings to make beaker happy
 pam::access::users:

--- a/spec/acceptance/suites/default/files/plain/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/files/plain/server_hieradata.yaml.erb
@@ -1,0 +1,2 @@
+# suP3rP@ssw0r!
+simp_openldap::server::conf::rootpw: "{SSHA}TghZyHW6r8/NL4fo0Q8BnihxVb7A7af5"

--- a/templates/create_home_directories.rb.erb
+++ b/templates/create_home_directories.rb.erb
@@ -34,6 +34,8 @@ tmout = 5
 
 ciphers_list = '<%= Array(@_tls_cipher_suite).join(':') %>'
 ca_path = '<%= @app_pki_ca_dir %>'
+cert_file = '<%= @app_pki_cert %>'
+key_file = '<%= @app_pki_key %>'
 
 begin
   Syslog.open('home_directories', Syslog::LOG_PID, syslog_facility)
@@ -84,11 +86,21 @@ servers.each do |svr|
       # NOTE: Binding with the host will automatically cease once the code
       # block is executed; only open() will create a persistent connection
       # which requires closing.
+      if ['ssl', 'start_tls'].include?(tls)
+        cert = OpenSSL::X509::Certificate.new(File.read(cert_file))
+        key = OpenSSL::PKey::RSA.new(File.read(key_file))
+        tls_options = {
+          :ciphers => ciphers_list,
+          :ca_path => ca_path,
+          :cert => cert,
+          :key => key
+        }
+      end
       conn_opts = {:host => svr, :port => <%= @port %>, :auth => {:method => :simple, :username => dn, :password => pw}}
       if tls == 'ssl'
-        conn_opts[:encryption] = { :method => :simple_tls, :tls_options => { :ciphers => ciphers_list, :ca_path => ca_path }}
+        conn_opts[:encryption] = { :method => :simple_tls, :tls_options => tls_options }
       elsif tls ==  'start_tls'
-        conn_opts[:encryption] = { :method => :start_tls, :tls_options => { :ciphers => ciphers_list, :ca_path => ca_path }}
+        conn_opts[:encryption] = { :method => :start_tls, :tls_options => tls_options }
       end
       conn = Net::LDAP.new(conn_opts)
       conn.bind


### PR DESCRIPTION
- Update the create_home_directory script to include nfs server
  pki certificate information.  This is needed because 389ds has
  client authentication set to 'require'.
- Change the cron to a systemd timer.
- Add configuration for 389ds server in acceptance tests and run
  nfs_server tests against it.

SIMP-9741 #close
SIMP-9737 #comment simp_nfs complete