### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -30,11 +30,9 @@ fixtures:
     simp: https://github.com/simp/pupmod-simp-simp.git
     simp_ds389: https://github.com/simp/pupmod-simp-simp_ds389.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
     sssd: https://github.com/simp/pupmod-simp-sssd.git
     ssh: https://github.com/simp/pupmod-simp-ssh.git
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     sudo: https://github.com/simp/pupmod-simp-sudo.git
     systemd: https://github.com/simp/puppet-systemd.git
-    tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git

--- a/spec/acceptance/suites/default/00_setup_389ds_spec.rb
+++ b/spec/acceptance/suites/default/00_setup_389ds_spec.rb
@@ -35,7 +35,6 @@ describe 'simp_nfs stock classes' do
         include 'ssh'
         include 'simp::nsswitch'
         include 'simp_ds389::instances::accounts'
-        include 'simp_openldap::client'
         include 'simp::sssd::client'
       EOM
 

--- a/spec/acceptance/suites/default/00_setup_ldap_spec.rb
+++ b/spec/acceptance/suites/default/00_setup_ldap_spec.rb
@@ -97,7 +97,6 @@ describe 'simp_nfs stock classes' do
         include 'sudo'
         include 'ssh'
         include 'simp::nsswitch'
-        include 'simp_openldap::client'
         include 'simp::sssd::client'
         include 'simp::server::ldap'
       EOM

--- a/spec/acceptance/suites/default/10_default_spec.rb
+++ b/spec/acceptance/suites/default/10_default_spec.rb
@@ -19,7 +19,6 @@ describe 'simp_nfs stock classes' do
     include 'sudo'
     include 'ssh'
     include 'simp::nsswitch'
-    include 'simp_openldap::client'
     include 'simp::sssd::client'
     include 'simp_nfs'
   EOM

--- a/spec/acceptance/suites/default/11_nostunnel_spec.rb
+++ b/spec/acceptance/suites/default/11_nostunnel_spec.rb
@@ -13,7 +13,6 @@ describe 'simp_nfs stock classes without stunnel' do
     include 'sudo'
     include 'ssh'
     include 'simp::nsswitch'
-    include 'simp_openldap::client'
     include 'simp::sssd::client'
     include 'simp_nfs'
     file {  '/mnt1':

--- a/spec/acceptance/suites/default/files/common_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/files/common_hieradata.yaml.erb
@@ -8,7 +8,6 @@ simp_options::ntpd::servers: ['time.nist.gov']
 simp_options::haveged: true
 simp_options::sssd: true
 simp_options::stunnel: <%= stunnel_setting %>
-simp_options::tcpwrappers: true
 simp_options::pam: true
 simp_options::firewall: true
 simp_options::pki: true

--- a/spec/acceptance/suites/default/files/plain/server_hieradata.yaml.erb
+++ b/spec/acceptance/suites/default/files/plain/server_hieradata.yaml.erb
@@ -1,2 +1,1 @@
 # suP3rP@ssw0r!
-simp_openldap::server::conf::rootpw: "{SSHA}TghZyHW6r8/NL4fo0Q8BnihxVb7A7af5"


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.